### PR TITLE
Fix voice addition issue

### DIFF
--- a/supabase/migrations/20250715100227-7ec9dfff-d5ff-4639-a769-92e998cab8fe.sql
+++ b/supabase/migrations/20250715100227-7ec9dfff-d5ff-4639-a769-92e998cab8fe.sql
@@ -6,6 +6,14 @@ ALTER TABLE public.voices
 ADD CONSTRAINT voices_voice_type_check 
 CHECK (voice_type IN ('conversational', 'narrative', 'ai', 'robotic', 'natural'));
 
+-- Add admin/service role insert policy for voices
+CREATE POLICY "Service role can insert any voice" 
+  ON public.voices 
+  FOR INSERT 
+  TO authenticated 
+  USING (auth.role() = 'service_role') 
+  WITH CHECK (true);
+
 -- Create generated_voices table for recent generations
 CREATE TABLE public.generated_voices (
   id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,


### PR DESCRIPTION
Add RLS policy to `voices` table to allow service role to insert voices.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-9e182eba-3217-4b62-bdb6-fe76c9e66b64) · [Cursor](https://cursor.com/background-agent?bcId=bc-9e182eba-3217-4b62-bdb6-fe76c9e66b64)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)